### PR TITLE
Optional population of "admin::user" attributes

### DIFF
--- a/server/bootstrap.js
+++ b/server/bootstrap.js
@@ -7,9 +7,10 @@ module.exports = ({ strapi }) => {
     if (event.action === 'beforeFindMany' || event.action === 'beforeFindOne') {
       const populate = event.params?.populate;
 
-      if (populate && populate[0] === 'deep') {
-        const depth = populate[1] ?? 5 
-        const modelObject = getFullPopulateObject(event.model.uid, depth);
+      if ((populate && populate[0] === 'deep') || (populate && populate[0] === 'deepua')) {
+        const depth = populate[1] ?? 5
+        const populateUserAdmin = (populate[0] === 'deepua' ? true : false)
+        const modelObject = getFullPopulateObject(event.model.uid, depth, populateUserAdmin);
         event.params.populate = modelObject.populate
       }
     }

--- a/server/helpers/index.js
+++ b/server/helpers/index.js
@@ -9,11 +9,11 @@ const getModelPopulationAttributes = (model) => {
   return model.attributes;
 };
 
-const getFullPopulateObject = (modelUid, maxDepth = 20) => {
+const getFullPopulateObject = (modelUid, maxDepth = 20, populateUserAdmin) => {
   if (maxDepth <= 1) {
     return true;
   }
-  if (modelUid === "admin::user") {
+  if (modelUid === "admin::user" && populateUserAdmin === false) {
     return undefined;
   }
 
@@ -24,17 +24,18 @@ const getFullPopulateObject = (modelUid, maxDepth = 20) => {
   )) {
     if (value) {
       if (value.type === "component") {
-        populate[key] = getFullPopulateObject(value.component, maxDepth - 1);
+        populate[key] = getFullPopulateObject(value.component, maxDepth - 1, populateUserAdmin);
       } else if (value.type === "dynamiczone") {
         const dynamicPopulate = value.components.reduce((prev, cur) => {
-          const curPopulate = getFullPopulateObject(cur, maxDepth - 1);
+          const curPopulate = getFullPopulateObject(cur, maxDepth - 1, populateUserAdmin);
           return curPopulate === true ? prev : merge(prev, curPopulate);
         }, {});
         populate[key] = isEmpty(dynamicPopulate) ? true : dynamicPopulate;
       } else if (value.type === "relation") {
         const relationPopulate = getFullPopulateObject(
           value.target,
-          maxDepth - 1
+          maxDepth - 1,
+          populateUserAdmin
         );
         if (relationPopulate) {
           populate[key] = relationPopulate;


### PR DESCRIPTION
Add the ability to get access to the "admin::user" attributes by replacing "populate=deep" with "populate=deepua"
This gives acces to 'createdBy' and 'updatedBy' in the sanitizedEntity, allowing to populate attributes manually in the controller ("admin::user" used to be rejected by default in the current version)