### PR TITLE
Node Engine Requirements typo fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "url": "https://github.com/Barelydead/strapi-plugin-deep-populate"
   },
   "engines": {
-    "node": ">=12.x. <=16.x.x",
+    "node": ">=12.x.x <=16.x.x",
     "npm": ">=6.0.0"
   },
   "license": "MIT"


### PR DESCRIPTION
Package fails when meeting requirements:
```
$ npm i
npm WARN EBADENGINE Unsupported engine {
npm WARN EBADENGINE   package: 'strapi-plugin-populate-deep@0.1.2',
npm WARN EBADENGINE   required: { node: '>=12.x. <=16.x.x', npm: '>=6.0.0' },
npm WARN EBADENGINE   current: { node: 'v16.13.2', npm: '8.1.2' }
npm WARN EBADENGINE }

```

This fixes it.