### PR TITLE
feat: add parametrization for default deep, and limit for max depth

### DIFF
--- a/server/bootstrap.js
+++ b/server/bootstrap.js
@@ -8,7 +8,7 @@ module.exports = ({ strapi }) => {
       const populate = event.params?.populate;
 
       if (populate && populate[0] === 'deep') {
-        const depth = populate[1] ?? 5 
+        const depth = populate[1] ?? process.env.DEEP_POPULATE_DEPTH ?? 5;
         const modelObject = getFullPopulateObject(event.model.uid, depth);
         event.params.populate = modelObject.populate
       }


### PR DESCRIPTION
Hey Christofer,
However, I encountered a security problem related to a possible DOS attack if the API is called with the deep parameter, <large number>. This causes the application to go out of memory and if it is managed through a process manager it is restarted, otherwise it crashes. I added in this fork a control with variables inserted directly into the .env file to allow users to customize the maximum and default depth.