### PR TITLE
Add parametrization for default deep, and limit for max depth

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "strapi-plugin-populate-deep-with-params",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "This is the description of the plugin.",
   "strapi": {
     "name": "strapi-plugin-populate-deep",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "strapi-plugin-populate-deep",
-  "version": "0.1.2",
+  "name": "strapi-plugin-populate-deep-with-params",
+  "version": "0.1.3",
   "description": "This is the description of the plugin.",
   "strapi": {
     "name": "strapi-plugin-populate-deep",
@@ -18,7 +18,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/Barelydead/strapi-plugin-deep-populate"
+    "url": "https://github.com/jacopobonomi/strapi-plugin-deep-populate"
   },
   "engines": {
     "node": ">=12.x. <=16.x.x",

--- a/server/bootstrap.js
+++ b/server/bootstrap.js
@@ -8,7 +8,7 @@ module.exports = ({ strapi }) => {
       const populate = event.params?.populate;
 
       if (populate && populate[0] === 'deep') {
-        const depth = populate[1] ?? 5 
+        const depth = populate[1] ?? process.env.DEFAULT_POPULATE_DEPTH ?? 5;
         const modelObject = getFullPopulateObject(event.model.uid, depth);
         event.params.populate = modelObject.populate
       }

--- a/server/helpers/index.js
+++ b/server/helpers/index.js
@@ -9,7 +9,10 @@ const getModelPopulationAttributes = (model) => {
   return model.attributes;
 };
 
-const getFullPopulateObject = (modelUid, maxDepth = 20) => {
+const getFullPopulateObject = (
+  modelUid,
+  maxDepth = process.env.MAX_POPULATE_DEPTH ?? 20
+) => {
   if (maxDepth <= 1) {
     return true;
   }
@@ -48,5 +51,5 @@ const getFullPopulateObject = (modelUid, maxDepth = 20) => {
 };
 
 module.exports = {
-  getFullPopulateObject
-}
+  getFullPopulateObject,
+};

--- a/server/helpers/index.js
+++ b/server/helpers/index.js
@@ -13,6 +13,11 @@ const getFullPopulateObject = (
   modelUid,
   maxDepth = process.env.MAX_POPULATE_DEPTH ?? 20
 ) => {
+
+  if (maxDepth > process.env.MAX_POPULATE_DEPTH) {
+    maxDepth = process.env.MAX_POPULATE_DEPTH;
+  }
+  
   if (maxDepth <= 1) {
     return true;
   }


### PR DESCRIPTION
Hey Christofer,
However, I encountered a security problem related to a possible DOS attack if the API is called with the deep parameter, . This causes the application to go out of memory and if it is managed through a process manager it is restarted, otherwise it crashes. I added in this fork a control with variables inserted directly into the .env file to allow users to customize the maximum and default depth.