### PR TITLE
Update index.js to allow 'admin::user' population with built-in Strapi option

### DIFF
--- a/server/helpers/index.js
+++ b/server/helpers/index.js
@@ -13,9 +13,6 @@ const getFullPopulateObject = (modelUid, maxDepth = 20) => {
   if (maxDepth <= 1) {
     return true;
   }
-  if (modelUid === "admin::user") {
-    return undefined;
-  }
 
   const populate = {};
   const model = strapi.getModel(modelUid);


### PR DESCRIPTION
Removing these 3 lines allow the built-in Strapi new option `populateCreatorFields": true` to work properly instead of being overridden and rejected by the plugin.