### PR TITLE
Fix conflicting keys on dynamic zone

### DIFF
--- a/server/helpers/index.js
+++ b/server/helpers/index.js
@@ -30,9 +30,9 @@ const getFullPopulateObject = (modelUid, maxDepth = 20) => {
       } else if (value.type === "dynamiczone") {
         const dynamicPopulate = value.components.reduce((prev, cur) => {
           const curPopulate = getFullPopulateObject(cur, maxDepth - 1);
-          return curPopulate === true ? prev : merge(prev, curPopulate);
+          return curPopulate === true ? prev : merge(prev, {[cur]: curPopulate});
         }, {});
-        populate[key] = isEmpty(dynamicPopulate) ? true : dynamicPopulate;
+        populate[key] = isEmpty(dynamicPopulate) ? true : { on: dynamicPopulate };
       } else if (value.type === "relation") {
         const relationPopulate = getFullPopulateObject(
           value.target,


### PR DESCRIPTION
As was described in #28 if multiple components share the same attribute name in a dynamic zone, components that are higher on the component list might not get their attributes populated.

Strapi provides two way to populate dynamic zones. As described by the docs:

> When populating dynamic zones, you can choose between:
> - a shared population strategy, applying a unique behavior for all the dynamic zone's components
> - or a detailed population strategy, defining per-component populate queries using the `on` property.

https://docs.strapi.io/dev-docs/api/rest/populate-select#components--dynamic-zones

This PR fixes this issue by utilizing the `on` keyword in dynamic components